### PR TITLE
Upgrade to live-share preview.12 w/ auto user displayName

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,13 @@
             "version": "1.0.0",
             "license": "Microsoft",
             "dependencies": {
-                "@fluidframework/test-client-utils": "~1.2.3",
-                "@microsoft/live-share": "1.0.0-preview.4",
-                "@microsoft/teams-js": "^2.5.0",
-                "fluid-framework": "~1.2.3"
+                "@fluidframework/azure-client": "~1.0.1",
+                "@microsoft/live-share": "1.0.0-preview.12",
+                "@microsoft/teams-js": "^2.11.0",
+                "fluid-framework": "^1.3.4"
             },
             "devDependencies": {
+                "@fluidframework/test-client-utils": "^1.3.4",
                 "clean-webpack-plugin": "^3.0.0",
                 "concurrently": "^5.3.0",
                 "html-webpack-plugin": "^4.3.0",
@@ -34,25 +35,25 @@
             }
         },
         "node_modules/@fluidframework/aqueduct": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.3.1.tgz",
-            "integrity": "sha512-1A0t6ZPM72gndAAoFD5oOF/z8PoggYvMnl+c8a0NZ3wyo8lrQIYftfTs4w2wi6TavQhUBjpL1HA6cx/MOAGceQ==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.3.6.tgz",
+            "integrity": "sha512-33vWqX1UEwYYTHb3Iv6+1B4ZFFcPNdD3cqfAmYbR7nOwxPYq1uKflUzafUOKW6SMpRyomeebCy/f5/PIoG+yJA==",
             "dependencies": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.32.1",
-                "@fluidframework/container-definitions": "^1.3.1",
-                "@fluidframework/container-loader": "^1.3.1",
-                "@fluidframework/container-runtime": "^1.3.1",
-                "@fluidframework/container-runtime-definitions": "^1.3.1",
-                "@fluidframework/core-interfaces": "^1.3.1",
-                "@fluidframework/datastore": "^1.3.1",
-                "@fluidframework/datastore-definitions": "^1.3.1",
-                "@fluidframework/map": "^1.3.1",
-                "@fluidframework/request-handler": "^1.3.1",
-                "@fluidframework/runtime-definitions": "^1.3.1",
-                "@fluidframework/runtime-utils": "^1.3.1",
-                "@fluidframework/synthesize": "^1.3.1",
-                "@fluidframework/view-interfaces": "^1.3.1",
+                "@fluidframework/common-utils": "^0.32.2",
+                "@fluidframework/container-definitions": "^1.3.6",
+                "@fluidframework/container-loader": "^1.3.6",
+                "@fluidframework/container-runtime": "^1.3.6",
+                "@fluidframework/container-runtime-definitions": "^1.3.6",
+                "@fluidframework/core-interfaces": "^1.3.6",
+                "@fluidframework/datastore": "^1.3.6",
+                "@fluidframework/datastore-definitions": "^1.3.6",
+                "@fluidframework/map": "^1.3.6",
+                "@fluidframework/request-handler": "^1.3.6",
+                "@fluidframework/runtime-definitions": "^1.3.6",
+                "@fluidframework/runtime-utils": "^1.3.6",
+                "@fluidframework/synthesize": "^1.3.6",
+                "@fluidframework/view-interfaces": "^1.3.6",
                 "uuid": "^8.3.1"
             }
         },
@@ -86,45 +87,46 @@
             "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
         },
         "node_modules/@fluidframework/common-utils": {
-            "version": "0.32.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
-            "integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+            "version": "0.32.2",
+            "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.2.tgz",
+            "integrity": "sha512-PoGX7/l0vWKt5JaAxcgFOdGje30Q6qSE06YzFIKh9Ba3oq7B60+TFqu7c2ErQt6sNddmvcAcAiLVNaTGAip3vw==",
             "dependencies": {
                 "@fluidframework/common-definitions": "^0.20.1",
                 "@types/events": "^3.0.0",
                 "base64-js": "^1.5.1",
+                "buffer": "^6.0.3",
                 "events": "^3.1.0",
                 "lodash": "^4.17.21",
                 "sha.js": "^2.4.11"
             }
         },
         "node_modules/@fluidframework/container-definitions": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.3.1.tgz",
-            "integrity": "sha512-5iL0RqtoKmXwSGWMsO1aPP5nGDZRsBtrDYVStN+OtSLkur4vmQMKPlYKz1XrrR9Bulr0or4VPWPVT8m1d+hZtQ==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.3.6.tgz",
+            "integrity": "sha512-+5fuIUG7jGjKrRHtrH2VgrRI0YUXcP9jSLrHdI4Ks+4kNSDiOlu+UT7j9T9KoBAfHOpnihS3PVeDBJtIeqgDZw==",
             "dependencies": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/core-interfaces": "^1.3.1",
-                "@fluidframework/driver-definitions": "^1.3.1",
+                "@fluidframework/core-interfaces": "^1.3.6",
+                "@fluidframework/driver-definitions": "^1.3.6",
                 "@fluidframework/protocol-definitions": "^0.1028.2000",
                 "events": "^3.1.0"
             }
         },
         "node_modules/@fluidframework/container-loader": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.3.1.tgz",
-            "integrity": "sha512-MoGxroxNW7lOcBSzS9hAhoqORH6b/PsB9HdvPA/Rl4thmgS9UY7VG3hfEc5pCkyr8D7cp1xJox3HjAv5QIDLXw==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.3.6.tgz",
+            "integrity": "sha512-J7nF7XTHCtL24gGnUhg155kolokX8HRWJqj2XEjaPrBsRmkyiySP+qCnrKY0bgLqaFLHW4WYfmC80lFE3oaELg==",
             "dependencies": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.32.1",
-                "@fluidframework/container-definitions": "^1.3.1",
-                "@fluidframework/container-utils": "^1.3.1",
-                "@fluidframework/core-interfaces": "^1.3.1",
-                "@fluidframework/driver-definitions": "^1.3.1",
-                "@fluidframework/driver-utils": "^1.3.1",
-                "@fluidframework/protocol-base": "^0.1036.5000",
+                "@fluidframework/common-utils": "^0.32.2",
+                "@fluidframework/container-definitions": "^1.3.6",
+                "@fluidframework/container-utils": "^1.3.6",
+                "@fluidframework/core-interfaces": "^1.3.6",
+                "@fluidframework/driver-definitions": "^1.3.6",
+                "@fluidframework/driver-utils": "^1.3.6",
+                "@fluidframework/protocol-base": "^0.1036.5001",
                 "@fluidframework/protocol-definitions": "^0.1028.2000",
-                "@fluidframework/telemetry-utils": "^1.3.1",
+                "@fluidframework/telemetry-utils": "^1.3.6",
                 "abort-controller": "^3.0.0",
                 "double-ended-queue": "^2.1.0-0",
                 "events": "^3.1.0",
@@ -134,215 +136,213 @@
             }
         },
         "node_modules/@fluidframework/container-runtime": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.3.1.tgz",
-            "integrity": "sha512-kggjfJv/DIyHgzvuW8Yg42mOEqV+V7j5QUzzVQ6rFnIo+fwMHCd4IIlpJyqyETISP0EoQQ+3AmzDg9q5EwcFLg==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.3.6.tgz",
+            "integrity": "sha512-YC1Bvd8UiO3YID/sU9yxMMibW0FPqpf+sS47Czg1ILf2twK48U2BopDDKNeIHJFDl3yNOqxJniUkJJLNoYWwqg==",
             "dependencies": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.32.1",
-                "@fluidframework/container-definitions": "^1.3.1",
-                "@fluidframework/container-runtime-definitions": "^1.3.1",
-                "@fluidframework/container-utils": "^1.3.1",
-                "@fluidframework/core-interfaces": "^1.3.1",
-                "@fluidframework/datastore": "^1.3.1",
-                "@fluidframework/driver-definitions": "^1.3.1",
-                "@fluidframework/driver-utils": "^1.3.1",
-                "@fluidframework/garbage-collector": "^1.3.1",
-                "@fluidframework/protocol-base": "^0.1036.5000",
+                "@fluidframework/common-utils": "^0.32.2",
+                "@fluidframework/container-definitions": "^1.3.6",
+                "@fluidframework/container-runtime-definitions": "^1.3.6",
+                "@fluidframework/container-utils": "^1.3.6",
+                "@fluidframework/core-interfaces": "^1.3.6",
+                "@fluidframework/datastore": "^1.3.6",
+                "@fluidframework/driver-definitions": "^1.3.6",
+                "@fluidframework/driver-utils": "^1.3.6",
+                "@fluidframework/garbage-collector": "^1.3.6",
+                "@fluidframework/protocol-base": "^0.1036.5001",
                 "@fluidframework/protocol-definitions": "^0.1028.2000",
-                "@fluidframework/runtime-definitions": "^1.3.1",
-                "@fluidframework/runtime-utils": "^1.3.1",
-                "@fluidframework/telemetry-utils": "^1.3.1",
+                "@fluidframework/runtime-definitions": "^1.3.6",
+                "@fluidframework/runtime-utils": "^1.3.6",
+                "@fluidframework/telemetry-utils": "^1.3.6",
                 "double-ended-queue": "^2.1.0-0",
                 "events": "^3.1.0",
                 "uuid": "^8.3.1"
             }
         },
         "node_modules/@fluidframework/container-runtime-definitions": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.3.1.tgz",
-            "integrity": "sha512-3V/XLqdPHkum+8iSsGgzosJLdxhEJkWPRsWoUxCpfo1IKerDlqzMDmHBvzvtAfG6CkuoVS1J+XiBF81SQUXi/Q==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.3.6.tgz",
+            "integrity": "sha512-cQP/F2F9BjeXKyUNmwQCRRb5qJPoufZ/iIyBSdj8qEYwhTyv3Ogbk+LyHz5cG8wPYlM2ff8IirxwEdgq7VTL/w==",
             "dependencies": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/container-definitions": "^1.3.1",
-                "@fluidframework/core-interfaces": "^1.3.1",
-                "@fluidframework/driver-definitions": "^1.3.1",
+                "@fluidframework/container-definitions": "^1.3.6",
+                "@fluidframework/core-interfaces": "^1.3.6",
+                "@fluidframework/driver-definitions": "^1.3.6",
                 "@fluidframework/protocol-definitions": "^0.1028.2000",
-                "@fluidframework/runtime-definitions": "^1.3.1",
-                "@types/node": "^14.18.0"
+                "@fluidframework/runtime-definitions": "^1.3.6"
             }
         },
         "node_modules/@fluidframework/container-utils": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.3.1.tgz",
-            "integrity": "sha512-56LOFOKpJ2blNsk4FQHoF3qU51Z8Xx4uiIhOgZXtlQvzTycZOIV6jmEehW1AaL25L4v+Dcf0a+SsZGzbXx7JyA==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.3.6.tgz",
+            "integrity": "sha512-Hf3kxHuRzQv3a7J+I/3q5OH3WW5lajy3ENucc1HLCuOKYi39MM5AfAMBEfaTl1aI5iMxhHEyDAZJhaGJvvgOew==",
             "dependencies": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.32.1",
-                "@fluidframework/container-definitions": "^1.3.1",
+                "@fluidframework/common-utils": "^0.32.2",
+                "@fluidframework/container-definitions": "^1.3.6",
                 "@fluidframework/protocol-definitions": "^0.1028.2000",
-                "@fluidframework/telemetry-utils": "^1.3.1"
+                "@fluidframework/telemetry-utils": "^1.3.6"
             }
         },
         "node_modules/@fluidframework/core-interfaces": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.3.1.tgz",
-            "integrity": "sha512-ecQmV/FVVJbRBjv2G6LjxRiMj4XsN2uOQXf8jtIe15ofWMYFMFPSl7sCKhJDQJlqhmbbP3qRksaQ5ExxFUdFuQ=="
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.3.6.tgz",
+            "integrity": "sha512-6ccflpLJvlPhZ58MiMUUC5XvWF1s5yTmP3dXHsJf514IzuAvS5PCGLdZWUjWCgxA2fPvZKzA4VfWpwyFt1H0LA=="
         },
         "node_modules/@fluidframework/datastore": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.3.1.tgz",
-            "integrity": "sha512-Tlj+LlKjgBTjJqFxvWUbtOwFFc/Y0oxdQ+MEHWZHcVeQIyTmOkXIdnv5XPtFmnSyExBTUdiQ53QeMoquip5aIw==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.3.6.tgz",
+            "integrity": "sha512-eQTkB/Z0Sn5JwZ66EvY3r4RflSoZth0Zi7ezD4kbx75c4wmixRSs+qGSMM0xbllFXjyA24ucbL21zduVLxZGcg==",
             "dependencies": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.32.1",
-                "@fluidframework/container-definitions": "^1.3.1",
-                "@fluidframework/container-utils": "^1.3.1",
-                "@fluidframework/core-interfaces": "^1.3.1",
-                "@fluidframework/datastore-definitions": "^1.3.1",
-                "@fluidframework/driver-definitions": "^1.3.1",
-                "@fluidframework/driver-utils": "^1.3.1",
-                "@fluidframework/garbage-collector": "^1.3.1",
-                "@fluidframework/protocol-base": "^0.1036.5000",
+                "@fluidframework/common-utils": "^0.32.2",
+                "@fluidframework/container-definitions": "^1.3.6",
+                "@fluidframework/container-utils": "^1.3.6",
+                "@fluidframework/core-interfaces": "^1.3.6",
+                "@fluidframework/datastore-definitions": "^1.3.6",
+                "@fluidframework/driver-definitions": "^1.3.6",
+                "@fluidframework/driver-utils": "^1.3.6",
+                "@fluidframework/garbage-collector": "^1.3.6",
+                "@fluidframework/protocol-base": "^0.1036.5001",
                 "@fluidframework/protocol-definitions": "^0.1028.2000",
-                "@fluidframework/runtime-definitions": "^1.3.1",
-                "@fluidframework/runtime-utils": "^1.3.1",
-                "@fluidframework/telemetry-utils": "^1.3.1",
+                "@fluidframework/runtime-definitions": "^1.3.6",
+                "@fluidframework/runtime-utils": "^1.3.6",
+                "@fluidframework/telemetry-utils": "^1.3.6",
                 "lodash": "^4.17.21",
                 "uuid": "^8.3.1"
             }
         },
         "node_modules/@fluidframework/datastore-definitions": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.3.1.tgz",
-            "integrity": "sha512-HgUVw4LN+nS6BOIlcfmtpd2txa0jcUQMb7ZkVhuXi6srmv1p4GsYTNcL+9aLMZecDqHcBGBRA12N+ss9ew0llg==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.3.6.tgz",
+            "integrity": "sha512-9kgqa5FsIHHuxQPL50cm/FX6FOukBDDHG45ByGEChISbnfkS13xncLrY6mE4FgTC1jW0d7y3CgGT3pn4n9Hc+g==",
             "dependencies": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.32.1",
-                "@fluidframework/container-definitions": "^1.3.1",
-                "@fluidframework/core-interfaces": "^1.3.1",
+                "@fluidframework/common-utils": "^0.32.2",
+                "@fluidframework/container-definitions": "^1.3.6",
+                "@fluidframework/core-interfaces": "^1.3.6",
                 "@fluidframework/protocol-definitions": "^0.1028.2000",
-                "@fluidframework/runtime-definitions": "^1.3.1",
-                "@types/node": "^14.18.0"
+                "@fluidframework/runtime-definitions": "^1.3.6"
             }
         },
         "node_modules/@fluidframework/driver-base": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.3.1.tgz",
-            "integrity": "sha512-MmHkUu8wLCD8cZKgld3mhgcps3KcCl/7HUMYhaqKlRd2iepsXj/HkqaU4VzAVazGGeGj8qzYOk5WAOl8G4N7sw==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.3.6.tgz",
+            "integrity": "sha512-Ini7PyyIP+out9+5eAqq+QYWfxSGprVtxTrtipmoKCjI6XTmgfmSwrs9VPrgdIl6lI52RjEFWQtC/J3vmjAesg==",
             "dependencies": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.32.1",
-                "@fluidframework/driver-definitions": "^1.3.1",
-                "@fluidframework/driver-utils": "^1.3.1",
+                "@fluidframework/common-utils": "^0.32.2",
+                "@fluidframework/driver-definitions": "^1.3.6",
+                "@fluidframework/driver-utils": "^1.3.6",
                 "@fluidframework/protocol-definitions": "^0.1028.2000",
-                "@fluidframework/telemetry-utils": "^1.3.1"
+                "@fluidframework/telemetry-utils": "^1.3.6"
             }
         },
         "node_modules/@fluidframework/driver-definitions": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.3.1.tgz",
-            "integrity": "sha512-V6LHydbVKTFFp1JVXI8uaNPlPCQ1c2JphBSiXKO/EVFOWMKdI8TtWW+Wnqwlg6zKGqIt+jevjGduT07ZMBFpXg==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.3.6.tgz",
+            "integrity": "sha512-5Rvk2NhXxh2bhk8WWnBtcJq/9TgVYhAj4z7DDuqXqJyRUF/XYhyxqOfMuo7IAhTa2oTpp8o7QDwZqsfWKfC9tA==",
             "dependencies": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/core-interfaces": "^1.3.1",
+                "@fluidframework/core-interfaces": "^1.3.6",
                 "@fluidframework/protocol-definitions": "^0.1028.2000"
             }
         },
         "node_modules/@fluidframework/driver-utils": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.3.1.tgz",
-            "integrity": "sha512-a8bP9URnNbxvE1ZpkZzV6t5+yBXLZUoYS8MAOLiMqOvmHc8gOdTDla49nXDWFIaGkL12GW4atbgKRTCHWvcSAQ==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.3.6.tgz",
+            "integrity": "sha512-yDbuR4eMj0Y+kbIwV0XaXd3kh+U1YxmU1Qgcxa2RgD3MEMsDiCBaQrUCPjjxmBT9diUfBijVxjjOc5vUfm/eBA==",
             "dependencies": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.32.1",
-                "@fluidframework/core-interfaces": "^1.3.1",
-                "@fluidframework/driver-definitions": "^1.3.1",
-                "@fluidframework/gitresources": "^0.1036.5000",
-                "@fluidframework/protocol-base": "^0.1036.5000",
+                "@fluidframework/common-utils": "^0.32.2",
+                "@fluidframework/core-interfaces": "^1.3.6",
+                "@fluidframework/driver-definitions": "^1.3.6",
+                "@fluidframework/gitresources": "^0.1036.5001",
+                "@fluidframework/protocol-base": "^0.1036.5001",
                 "@fluidframework/protocol-definitions": "^0.1028.2000",
-                "@fluidframework/telemetry-utils": "^1.3.1",
+                "@fluidframework/telemetry-utils": "^1.3.6",
                 "axios": "^0.26.0",
                 "uuid": "^8.3.1"
             }
         },
         "node_modules/@fluidframework/fluid-static": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.3.1.tgz",
-            "integrity": "sha512-x2QHJgse5U7GVM1TXwt3SbyU61x6pS/W+IycVuEw9MkEKDcmo8oWE/SjdF3O4TVO/UEh4dQ15YdgRYXkpaNy+Q==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.3.6.tgz",
+            "integrity": "sha512-ncGgaDmewFQJou9roh+8K94hhpIlNEGvLaxNnofgFHAq1R2vLlx+zb5VGMMywnof+gvjgrsk4JOP2C9XpMs9Tw==",
             "dependencies": {
-                "@fluidframework/aqueduct": "^1.3.1",
+                "@fluidframework/aqueduct": "^1.3.6",
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.32.1",
-                "@fluidframework/container-definitions": "^1.3.1",
-                "@fluidframework/container-loader": "^1.3.1",
-                "@fluidframework/container-runtime-definitions": "^1.3.1",
-                "@fluidframework/core-interfaces": "^1.3.1",
-                "@fluidframework/datastore-definitions": "^1.3.1",
+                "@fluidframework/common-utils": "^0.32.2",
+                "@fluidframework/container-definitions": "^1.3.6",
+                "@fluidframework/container-loader": "^1.3.6",
+                "@fluidframework/container-runtime-definitions": "^1.3.6",
+                "@fluidframework/core-interfaces": "^1.3.6",
+                "@fluidframework/datastore-definitions": "^1.3.6",
                 "@fluidframework/protocol-definitions": "^0.1028.2000",
-                "@fluidframework/request-handler": "^1.3.1",
-                "@fluidframework/runtime-definitions": "^1.3.1",
-                "@fluidframework/runtime-utils": "^1.3.1"
+                "@fluidframework/request-handler": "^1.3.6",
+                "@fluidframework/runtime-definitions": "^1.3.6",
+                "@fluidframework/runtime-utils": "^1.3.6"
             }
         },
         "node_modules/@fluidframework/garbage-collector": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.3.1.tgz",
-            "integrity": "sha512-wVwwaXhmPRmkU2HnXRhy/aRCR2vL73xeCy1VmGF2b6z6FWvxASb1ygKtEZEoSI7NkcbsqzfYYCbcf/K7UgYJ9A==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.3.6.tgz",
+            "integrity": "sha512-uJpvkWNzTsLJAmGwu6LUjR8cVoAzlfmhxoudaGrA3DeWhGheDcGVP/hiKht+pMw3u1CCA4AKOfE+0bIOQXyFBA==",
             "dependencies": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.32.1",
-                "@fluidframework/runtime-definitions": "^1.3.1"
+                "@fluidframework/common-utils": "^0.32.2",
+                "@fluidframework/runtime-definitions": "^1.3.6"
             }
         },
         "node_modules/@fluidframework/gitresources": {
-            "version": "0.1036.5000",
-            "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
-            "integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
+            "version": "0.1036.5001",
+            "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5001.tgz",
+            "integrity": "sha512-Beg1A/eR7wCPYYb5u5iqqc092NkWnSvl4XCn2ImA4FDKtnYggD2/KYd9Hp0feM6Z99aU4FYSBidL2NewWlvF7A=="
         },
         "node_modules/@fluidframework/map": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.3.1.tgz",
-            "integrity": "sha512-3AccKnnaAYNU7delvlR2tSpEhFkyWYPFg09kgwgU9pRgK9JIGPrwySPW5LPxzP0BoFmvk+VaTaBeXMI1SKzpaQ==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.3.6.tgz",
+            "integrity": "sha512-CEuDHKLbJGt8SwwyUKoY1ZBkeFcn7Y+XPbm6lqsctYM08Fz2n1IsI6cl7KqppR3xJ2SpGyzDnVzNXeiPyOapfQ==",
             "dependencies": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.32.1",
-                "@fluidframework/container-utils": "^1.3.1",
-                "@fluidframework/core-interfaces": "^1.3.1",
-                "@fluidframework/datastore-definitions": "^1.3.1",
-                "@fluidframework/driver-utils": "^1.3.1",
+                "@fluidframework/common-utils": "^0.32.2",
+                "@fluidframework/container-utils": "^1.3.6",
+                "@fluidframework/core-interfaces": "^1.3.6",
+                "@fluidframework/datastore-definitions": "^1.3.6",
+                "@fluidframework/driver-utils": "^1.3.6",
                 "@fluidframework/protocol-definitions": "^0.1028.2000",
-                "@fluidframework/runtime-definitions": "^1.3.1",
-                "@fluidframework/runtime-utils": "^1.3.1",
-                "@fluidframework/shared-object-base": "^1.3.1",
+                "@fluidframework/runtime-definitions": "^1.3.6",
+                "@fluidframework/runtime-utils": "^1.3.6",
+                "@fluidframework/shared-object-base": "^1.3.6",
                 "path-browserify": "^1.0.1"
             }
         },
         "node_modules/@fluidframework/merge-tree": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.3.1.tgz",
-            "integrity": "sha512-Sv6AjBoHWpAj053zvGEI8G5zTLE+JnvfbsUATkMSmmXco6gizxkjkxQGGugBHWZr/hGnjqHTxl0D4YzmRw0FYQ==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.3.6.tgz",
+            "integrity": "sha512-a7ZYHpbKO5as+SxKbiqAlxYXK/vmaWY0A8n1O5dTjgElHaJkuxaKKczczr9tBrAxQ7JYNZ0Sq3e6n5hm2gfU4g==",
             "dependencies": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.32.1",
-                "@fluidframework/container-definitions": "^1.3.1",
-                "@fluidframework/container-utils": "^1.3.1",
-                "@fluidframework/core-interfaces": "^1.3.1",
-                "@fluidframework/datastore-definitions": "^1.3.1",
+                "@fluidframework/common-utils": "^0.32.2",
+                "@fluidframework/container-definitions": "^1.3.6",
+                "@fluidframework/container-utils": "^1.3.6",
+                "@fluidframework/core-interfaces": "^1.3.6",
+                "@fluidframework/datastore-definitions": "^1.3.6",
                 "@fluidframework/protocol-definitions": "^0.1028.2000",
-                "@fluidframework/runtime-definitions": "^1.3.1",
-                "@fluidframework/runtime-utils": "^1.3.1",
-                "@fluidframework/shared-object-base": "^1.3.1",
-                "@fluidframework/telemetry-utils": "^1.3.1"
+                "@fluidframework/runtime-definitions": "^1.3.6",
+                "@fluidframework/runtime-utils": "^1.3.6",
+                "@fluidframework/shared-object-base": "^1.3.6",
+                "@fluidframework/telemetry-utils": "^1.3.6"
             }
         },
         "node_modules/@fluidframework/protocol-base": {
-            "version": "0.1036.5000",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
-            "integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
+            "version": "0.1036.5001",
+            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5001.tgz",
+            "integrity": "sha512-Btjy2bWVbVsmzNTBxTQZ9l/WXljsjDpGbBgJsn9GLacrTG9aDDtIVMXuwLAcEV1IVkxGcIipXryvfhbPHDYcMg==",
             "dependencies": {
-                "@fluidframework/common-utils": "^0.32.1",
-                "@fluidframework/gitresources": "^0.1036.5000",
+                "@fluidframework/common-utils": "^0.32.2",
+                "@fluidframework/gitresources": "^0.1036.5001",
                 "@fluidframework/protocol-definitions": "^0.1028.2000",
                 "lodash": "^4.17.21"
             }
@@ -356,32 +356,32 @@
             }
         },
         "node_modules/@fluidframework/request-handler": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.3.1.tgz",
-            "integrity": "sha512-zWkMXjHmfHWGxmws7JITBzz76CkNQehidBxrO1tgeoitd6wXrfQsC8jXybY7+Gft6DcJCXFcWA6wWLiKUrg1Sw==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.3.6.tgz",
+            "integrity": "sha512-4z0XRVuj3mu6ZYceUbTf/DZfRt1u0cClnpVZPthEs26QSk6LJvEpt5UBE3oIGkESoxZ3LHtAnkS2zCEl8jcrFw==",
             "dependencies": {
-                "@fluidframework/common-utils": "^0.32.1",
-                "@fluidframework/container-runtime-definitions": "^1.3.1",
-                "@fluidframework/core-interfaces": "^1.3.1",
-                "@fluidframework/runtime-definitions": "^1.3.1",
-                "@fluidframework/runtime-utils": "^1.3.1"
+                "@fluidframework/common-utils": "^0.32.2",
+                "@fluidframework/container-runtime-definitions": "^1.3.6",
+                "@fluidframework/core-interfaces": "^1.3.6",
+                "@fluidframework/runtime-definitions": "^1.3.6",
+                "@fluidframework/runtime-utils": "^1.3.6"
             }
         },
         "node_modules/@fluidframework/routerlicious-driver": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.3.1.tgz",
-            "integrity": "sha512-KtxS05qy4mNrMvFifCJn7bE83KUXvMPGpdYxI33kii2A5yXwf+T3OAdwJDfqiqtx6GsORkWW2lvxaXtLQtQdvg==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.3.6.tgz",
+            "integrity": "sha512-b9NXLWI7YH4l2dEkgjDuIF9BNb1ggxkzS8ZtZpr+eBtegRN+E+WSbkR7JCPwrDmA+vPa9z0mXNS88ZeCwnQp3A==",
             "dependencies": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.32.1",
-                "@fluidframework/driver-base": "^1.3.1",
-                "@fluidframework/driver-definitions": "^1.3.1",
-                "@fluidframework/driver-utils": "^1.3.1",
-                "@fluidframework/gitresources": "^0.1036.5000",
-                "@fluidframework/protocol-base": "^0.1036.5000",
+                "@fluidframework/common-utils": "^0.32.2",
+                "@fluidframework/driver-base": "^1.3.6",
+                "@fluidframework/driver-definitions": "^1.3.6",
+                "@fluidframework/driver-utils": "^1.3.6",
+                "@fluidframework/gitresources": "^0.1036.5001",
+                "@fluidframework/protocol-base": "^0.1036.5001",
                 "@fluidframework/protocol-definitions": "^0.1028.2000",
-                "@fluidframework/server-services-client": "^0.1036.5000",
-                "@fluidframework/telemetry-utils": "^1.3.1",
+                "@fluidframework/server-services-client": "^0.1036.5001",
+                "@fluidframework/telemetry-utils": "^1.3.6",
                 "cross-fetch": "^3.1.5",
                 "json-stringify-safe": "5.0.1",
                 "querystring": "^0.2.0",
@@ -391,64 +391,63 @@
             }
         },
         "node_modules/@fluidframework/runtime-definitions": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.3.1.tgz",
-            "integrity": "sha512-koLyVpG/lQpZMF3RvuRZF0EdfmJt3+sliRbBiYFK8VxGRAEJ7dRWYctRbYXxce3fkemCg+1li38LS1cxvzqsuw==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.3.6.tgz",
+            "integrity": "sha512-sFCUkN4sCz1ww7XKhIFiiXuaUtrps8Dd4h0VaYLsvzkH9bD/lcbbcvgmaMmqPa3tOy0ROsLAM5QSr5jBYipidw==",
             "dependencies": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.32.1",
-                "@fluidframework/container-definitions": "^1.3.1",
-                "@fluidframework/core-interfaces": "^1.3.1",
-                "@fluidframework/driver-definitions": "^1.3.1",
-                "@fluidframework/protocol-definitions": "^0.1028.2000",
-                "@types/node": "^14.18.0"
+                "@fluidframework/common-utils": "^0.32.2",
+                "@fluidframework/container-definitions": "^1.3.6",
+                "@fluidframework/core-interfaces": "^1.3.6",
+                "@fluidframework/driver-definitions": "^1.3.6",
+                "@fluidframework/protocol-definitions": "^0.1028.2000"
             }
         },
         "node_modules/@fluidframework/runtime-utils": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.3.1.tgz",
-            "integrity": "sha512-SnTKhKZX2VGkr3Pnvp5R1ARbNRyqsFyGGmUi1xm6ZhK44urLKZA24+YF13agdmgn2moMZM4Cbws2r3N9v7IqAg==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.3.6.tgz",
+            "integrity": "sha512-Yl0oWTcUwgDBWIaW6UsyfHE9D5yhmY11lx5ij3RcEn2Up07mD7+DzFXvxXTjdCioc4B0ssad70vvGJKJOwk6Nw==",
             "dependencies": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.32.1",
-                "@fluidframework/container-definitions": "^1.3.1",
-                "@fluidframework/container-runtime-definitions": "^1.3.1",
-                "@fluidframework/core-interfaces": "^1.3.1",
-                "@fluidframework/datastore-definitions": "^1.3.1",
-                "@fluidframework/garbage-collector": "^1.3.1",
-                "@fluidframework/protocol-base": "^0.1036.5000",
+                "@fluidframework/common-utils": "^0.32.2",
+                "@fluidframework/container-definitions": "^1.3.6",
+                "@fluidframework/container-runtime-definitions": "^1.3.6",
+                "@fluidframework/core-interfaces": "^1.3.6",
+                "@fluidframework/datastore-definitions": "^1.3.6",
+                "@fluidframework/garbage-collector": "^1.3.6",
+                "@fluidframework/protocol-base": "^0.1036.5001",
                 "@fluidframework/protocol-definitions": "^0.1028.2000",
-                "@fluidframework/runtime-definitions": "^1.3.1",
-                "@fluidframework/telemetry-utils": "^1.3.1"
+                "@fluidframework/runtime-definitions": "^1.3.6",
+                "@fluidframework/telemetry-utils": "^1.3.6"
             }
         },
         "node_modules/@fluidframework/sequence": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.3.1.tgz",
-            "integrity": "sha512-ZkPju0rPMrluyjV9Tqi5nT6/1S3l3nrfChs9NdWqd+9jDES/i0VuyuQp+ObmXmtKAqRDLcteIFBWBeBOrQMnXg==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.3.6.tgz",
+            "integrity": "sha512-XGtwifGkakcUxAnaEyM23CaG/avK1a87odb2uhbiwP2k3g55aSe2PsOhmtJVVrs1Yv775Xc1jGUotRKiNzLY7w==",
             "dependencies": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.32.1",
-                "@fluidframework/container-utils": "^1.3.1",
-                "@fluidframework/core-interfaces": "^1.3.1",
-                "@fluidframework/datastore-definitions": "^1.3.1",
-                "@fluidframework/merge-tree": "^1.3.1",
+                "@fluidframework/common-utils": "^0.32.2",
+                "@fluidframework/container-utils": "^1.3.6",
+                "@fluidframework/core-interfaces": "^1.3.6",
+                "@fluidframework/datastore-definitions": "^1.3.6",
+                "@fluidframework/merge-tree": "^1.3.6",
                 "@fluidframework/protocol-definitions": "^0.1028.2000",
-                "@fluidframework/runtime-definitions": "^1.3.1",
-                "@fluidframework/runtime-utils": "^1.3.1",
-                "@fluidframework/shared-object-base": "^1.3.1",
-                "@fluidframework/telemetry-utils": "^1.3.1",
+                "@fluidframework/runtime-definitions": "^1.3.6",
+                "@fluidframework/runtime-utils": "^1.3.6",
+                "@fluidframework/shared-object-base": "^1.3.6",
+                "@fluidframework/telemetry-utils": "^1.3.6",
                 "uuid": "^8.3.1"
             }
         },
         "node_modules/@fluidframework/server-services-client": {
-            "version": "0.1036.5000",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5000.tgz",
-            "integrity": "sha512-TBig0U1Fne0h10H6Sylcf6pe9PrYJy6PkLvTv+MX9ojuWsyPJbbhkPX/L2Gj/wmzDY+psvhA2TSLDZOMnpshpw==",
+            "version": "0.1036.5001",
+            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5001.tgz",
+            "integrity": "sha512-e+Zk2uPcds9yqlalAZ0PpfEAKPPUIpIoQb3YSm42ZVpAgQmLYIRqTpXrmTC7qdeQnSGFJUAliW4DfHBEwpSXlQ==",
             "dependencies": {
-                "@fluidframework/common-utils": "^0.32.1",
-                "@fluidframework/gitresources": "^0.1036.5000",
-                "@fluidframework/protocol-base": "^0.1036.5000",
+                "@fluidframework/common-utils": "^0.32.2",
+                "@fluidframework/gitresources": "^0.1036.5001",
+                "@fluidframework/protocol-base": "^0.1036.5001",
                 "@fluidframework/protocol-definitions": "^0.1028.2000",
                 "axios": "^0.26.0",
                 "crc-32": "1.2.0",
@@ -462,69 +461,71 @@
             }
         },
         "node_modules/@fluidframework/shared-object-base": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.3.1.tgz",
-            "integrity": "sha512-rHk2ofuZH+gyxbKqm18LkOdwZBHgbo0RImPZsE1YxDNj5aqe9+6aQsP9q0KTTkPWFRKoWmeWyKQOnVjyX71SGg==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.3.6.tgz",
+            "integrity": "sha512-eUMtIosNBwDJXpw69BJuOLGJw4Lf53f6sU6ZgNKU1l2C5/Ht7gG2iDEBxYnNUvVAMQprTHYt5T1qTwn8uaT+Lw==",
             "dependencies": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.32.1",
-                "@fluidframework/container-definitions": "^1.3.1",
-                "@fluidframework/container-runtime": "^1.3.1",
-                "@fluidframework/container-utils": "^1.3.1",
-                "@fluidframework/core-interfaces": "^1.3.1",
-                "@fluidframework/datastore": "^1.3.1",
-                "@fluidframework/datastore-definitions": "^1.3.1",
+                "@fluidframework/common-utils": "^0.32.2",
+                "@fluidframework/container-definitions": "^1.3.6",
+                "@fluidframework/container-runtime": "^1.3.6",
+                "@fluidframework/container-utils": "^1.3.6",
+                "@fluidframework/core-interfaces": "^1.3.6",
+                "@fluidframework/datastore": "^1.3.6",
+                "@fluidframework/datastore-definitions": "^1.3.6",
                 "@fluidframework/protocol-definitions": "^0.1028.2000",
-                "@fluidframework/runtime-definitions": "^1.3.1",
-                "@fluidframework/runtime-utils": "^1.3.1",
-                "@fluidframework/telemetry-utils": "^1.3.1",
+                "@fluidframework/runtime-definitions": "^1.3.6",
+                "@fluidframework/runtime-utils": "^1.3.6",
+                "@fluidframework/telemetry-utils": "^1.3.6",
                 "uuid": "^8.3.1"
             }
         },
         "node_modules/@fluidframework/synthesize": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.3.1.tgz",
-            "integrity": "sha512-Qs8G8mEaJ1AuaKuH1+Zsuh3qjyqtxsjCIwXnSARZM7n7I70pIUJbdjCRPVHriH+oMthONI6ieUV42e3zxfPasQ=="
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.3.6.tgz",
+            "integrity": "sha512-avt0K5uxvOjs1Y6XpisonkMmG3RaI901h5XfIWFlxOhkHSgeN7T3ZmTdAinlpyRv+XKHzVzN1SqaccpGeC0+lw=="
         },
         "node_modules/@fluidframework/telemetry-utils": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.3.1.tgz",
-            "integrity": "sha512-oYWHm3F+SjGRkWGbQ+ud86CJuQsQqZYyTCFbyctv0Zf1fKVuVA9KXOmVK7KpSzDdFFjF31DhkbjN8/DS/ak67g==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.3.6.tgz",
+            "integrity": "sha512-9DoLzKwnELWBN2NiCJPgfj2lCER4IiHSgiBMwbLoEZ0qTqGKhWJ1+7m1PupuwGuKX1zbb9HjUNxv2ommokZcqw==",
             "dependencies": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.32.1",
+                "@fluidframework/common-utils": "^0.32.2",
                 "debug": "^4.1.1",
                 "events": "^3.1.0",
                 "uuid": "^8.3.1"
             }
         },
         "node_modules/@fluidframework/test-client-utils": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@fluidframework/test-client-utils/-/test-client-utils-1.2.7.tgz",
-            "integrity": "sha512-ORCY2bG7IkVVR7Ud73lHfjONmMOO8jdfKIC6YxUwP5AUvCaTyrmzCkJkdfLjEGsLDuVocUBf5lL/G4Ylgz9gHw==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@fluidframework/test-client-utils/-/test-client-utils-1.3.6.tgz",
+            "integrity": "sha512-bwF/R/dDhpjwTQPlZvy/nqYApzLaBV7abolBhB3dKDdMPEDDqhTQP3pLreY3c43c+TLvInwYZCXeruAQlItocQ==",
+            "dev": true,
             "dependencies": {
                 "@fluidframework/protocol-definitions": "^0.1028.2000",
-                "@fluidframework/test-runtime-utils": "^1.2.7",
+                "@fluidframework/test-runtime-utils": "^1.3.6",
                 "sillyname": "^0.1.0"
             }
         },
         "node_modules/@fluidframework/test-runtime-utils": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.3.1.tgz",
-            "integrity": "sha512-Mou5KktwmnmDnFommCRsyckmdOSLnteKCVQMVFDV3AwA7n+FE1ABscWwJX0VHmAQgeP90hESb6dStjuWBLae7g==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.3.6.tgz",
+            "integrity": "sha512-OoYH8Ht2nIqEwcnbz4Cg4sGk0HTkKg0+dNmZ7aP4qzctibKdNwObmypdia3MMmx16hpQRExhzO1d0ut/fRzLkA==",
+            "dev": true,
             "dependencies": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.32.1",
-                "@fluidframework/container-definitions": "^1.3.1",
-                "@fluidframework/core-interfaces": "^1.3.1",
-                "@fluidframework/datastore-definitions": "^1.3.1",
-                "@fluidframework/driver-definitions": "^1.3.1",
-                "@fluidframework/driver-utils": "^1.3.1",
+                "@fluidframework/common-utils": "^0.32.2",
+                "@fluidframework/container-definitions": "^1.3.6",
+                "@fluidframework/core-interfaces": "^1.3.6",
+                "@fluidframework/datastore-definitions": "^1.3.6",
+                "@fluidframework/driver-definitions": "^1.3.6",
+                "@fluidframework/driver-utils": "^1.3.6",
                 "@fluidframework/protocol-definitions": "^0.1028.2000",
-                "@fluidframework/routerlicious-driver": "^1.3.1",
-                "@fluidframework/runtime-definitions": "^1.3.1",
-                "@fluidframework/runtime-utils": "^1.3.1",
-                "@fluidframework/telemetry-utils": "^1.3.1",
+                "@fluidframework/routerlicious-driver": "^1.3.6",
+                "@fluidframework/runtime-definitions": "^1.3.6",
+                "@fluidframework/runtime-utils": "^1.3.6",
+                "@fluidframework/telemetry-utils": "^1.3.6",
                 "axios": "^0.26.0",
                 "events": "^3.1.0",
                 "jsrsasign": "^10.5.25",
@@ -532,11 +533,11 @@
             }
         },
         "node_modules/@fluidframework/view-interfaces": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.3.1.tgz",
-            "integrity": "sha512-9w1SfUypzSUuDT5qXYhciDYaGFerIJV3iaV3EaAzmm/GMRDSCOtC41ZFJ6O8J+aOtI65YyqQLv0FS53XU4hE/A==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.3.6.tgz",
+            "integrity": "sha512-QEBEPmJdNCO7BdCjUaFxA32fjH91LePRs2xMV5iK8KRQwkyYnp4kRa3nKD3Iv2ezYKG+MvtAIDmUvfzICwWxUA==",
             "dependencies": {
-                "@fluidframework/core-interfaces": "^1.3.1"
+                "@fluidframework/core-interfaces": "^1.3.6"
             }
         },
         "node_modules/@hapi/hoek": {
@@ -613,38 +614,31 @@
             }
         },
         "node_modules/@microsoft/live-share": {
-            "version": "1.0.0-preview.4",
-            "resolved": "https://registry.npmjs.org/@microsoft/live-share/-/live-share-1.0.0-preview.4.tgz",
-            "integrity": "sha512-nrItok95gvGSHUDnLrxBCtUt0MY47JI5h4LW/nwOTLz7/3SXy7WSqm6SpJr3VUPVriGtSXl8RaaYLU1PSbjRgg==",
+            "version": "1.0.0-preview.12",
+            "resolved": "https://registry.npmjs.org/@microsoft/live-share/-/live-share-1.0.0-preview.12.tgz",
+            "integrity": "sha512-L3QiugUPyosYFqeaO0NLVvRw1wFkWiR1LKFmXyc59/XWe1Ohrw3V4bcm95JYT7Hi1UOeC4/SEoUf6B6nNYt98w==",
             "dependencies": {
-                "@fluidframework/azure-client": "~1.0.2",
-                "@fluidframework/test-client-utils": "~1.2.3",
-                "fluid-framework": "~1.2.3",
-                "uuid": "^8.3.2"
+                "uuid": "^9.0.0"
+            },
+            "peerDependencies": {
+                "@fluidframework/azure-client": "^1.0.0",
+                "fluid-framework": "^1.2.3"
+            }
+        },
+        "node_modules/@microsoft/live-share/node_modules/uuid": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+            "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@microsoft/teams-js": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/teams-js/-/teams-js-2.5.0.tgz",
-            "integrity": "sha512-9dD6E2tzWpvykMeXCru3crw1V1hlozpLRidJJFoLxv2f6OtpbL93PWl/KZnvnNVYJQmp06404IgyzcbSa07gnA==",
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/teams-js/-/teams-js-2.11.0.tgz",
+            "integrity": "sha512-XmNSFSCuJKRWsCmzkSCKC7+iiBC2+48ihJGm8AnaltKot3dF6J5ML851AtMC2Oi7WB1iuM3nej7PgdzdDK39fg==",
             "dependencies": {
-                "debug": "4.3.3"
-            }
-        },
-        "node_modules/@microsoft/teams-js/node_modules/debug": {
-            "version": "4.3.3",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-            "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
+                "debug": "^4.3.3"
             }
         },
         "node_modules/@sideway/address": {
@@ -735,7 +729,8 @@
         "node_modules/@types/node": {
             "version": "14.18.33",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.33.tgz",
-            "integrity": "sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg=="
+            "integrity": "sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg==",
+            "dev": true
         },
         "node_modules/@types/source-list-map": {
             "version": "0.1.2",
@@ -1472,6 +1467,29 @@
             },
             "engines": {
                 "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+            }
+        },
+        "node_modules/buffer": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.2.1"
             }
         },
         "node_modules/buffer-from": {
@@ -3080,15 +3098,16 @@
             }
         },
         "node_modules/fluid-framework": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-1.2.7.tgz",
-            "integrity": "sha512-sAvXg4PsPkbXKuPWmr4lM+TWcw/5jkAUzRfqpeJJQKua0pe+NioM2KhanFmdl68FTNESOkFfr1qKcBmEA+xXgA==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-1.3.6.tgz",
+            "integrity": "sha512-RW+yqWitqAQgX1GsY9pynUEHtQm7Yw5em9BDj29LAzBtLonS4dmqW146qLLD9IJAbF31EfSyBlvLyWHqdqhI6w==",
             "dependencies": {
-                "@fluidframework/container-definitions": "^1.2.7",
-                "@fluidframework/container-loader": "^1.2.7",
-                "@fluidframework/fluid-static": "^1.2.7",
-                "@fluidframework/map": "^1.2.7",
-                "@fluidframework/sequence": "^1.2.7"
+                "@fluidframework/container-definitions": "^1.3.6",
+                "@fluidframework/container-loader": "^1.3.6",
+                "@fluidframework/driver-definitions": "^1.3.6",
+                "@fluidframework/fluid-static": "^1.3.6",
+                "@fluidframework/map": "^1.3.6",
+                "@fluidframework/sequence": "^1.3.6"
             }
         },
         "node_modules/follow-redirects": {
@@ -3639,6 +3658,25 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
         },
         "node_modules/import-local": {
             "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -11,15 +11,16 @@
         "build:dev": "webpack --env clean",
         "start": "start-server-and-test start:server 7070 start:client",
         "start:client": "webpack serve",
-        "start:server": "npx @fluidframework/azure-local-service@latest"
+        "start:server": "npx tinylicious@latest"
     },
     "dependencies": {
-        "@fluidframework/test-client-utils": "~1.2.3",
-        "@microsoft/live-share": "1.0.0-preview.4",
-        "@microsoft/teams-js": "^2.5.0",
-        "fluid-framework": "~1.2.3"
+        "@fluidframework/azure-client": "~1.0.1",
+        "@microsoft/live-share": "1.0.0-preview.12",
+        "@microsoft/teams-js": "^2.11.0",
+        "fluid-framework": "^1.3.4"
     },
     "devDependencies": {
+        "@fluidframework/test-client-utils": "^1.3.4",
         "clean-webpack-plugin": "^3.0.0",
         "concurrently": "^5.3.0",
         "html-webpack-plugin": "^4.3.0",


### PR DESCRIPTION
Upgraded Live Share to version `1.0.0-preview.12`, which includes support for automatically populating the user `displayName`.

![image](https://user-images.githubusercontent.com/11748606/236515299-e9607de0-3dac-4776-bf0c-251318fdb3ac.png)

Locally, the user is rendered as a hash of their `clientId`. In Teams (currently up to v3.6, in R4 by Build) it uses their actual `displayName`.

For more information on this update, you can read our patch notes here: https://github.com/microsoft/live-share-sdk/releases/tag/v1.0.0-preview.12